### PR TITLE
Add per-call step job options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add per-call `step_job_options:` to `Workflow.create` / `create!`. Options are persisted on the workflow row, merged over class-level `set_step_job_options`, and reused for later steps, reattempts, and resumed scheduled executions. Existing installs get an additive migration for nullable `geneva_drive_workflows.step_job_options` by rerunning `bin/rails generate geneva_drive:install`.
 - Add `report:` option to exception policies and class-level `on_exception` for controlling when exceptions are reported to `Rails.error.report`. Accepts `:always` (default — preserves existing behavior), `:never` (suppress reporting for expected exceptions like rate limits), or `:terminal_only` (suppress during reattempts, report only when `terminal_action` fires). The executor now defers error reporting until after policy resolution.
 
 ## [0.5.0]

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1250,7 +1250,7 @@ SyncGmailWorkflow.create!(
 
 The per-call options are persisted on the workflow row and merged over the class-level options. That means later steps, reattempts, and resumed scheduled executions keep the same queue or priority. This is useful when the same workflow can be started by both low-priority background polling and high-priority user actions: keep one workflow class for dedupe, but give the user-triggered run priority treatment.
 
-Supported keys are the ActiveJob `set` options GenevaDrive passes through: `queue`, `priority`, `wait`, and `wait_until`. Step scheduling remains authoritative for actual step delays, so a step's own `wait:` still sets the runtime `wait_until`.
+Supported keys are `queue` and `priority`. Step timing still belongs in GenevaDrive's step DSL (`step :name, wait: 5.minutes`) or in flow control (`reattempt!(wait: 1.minute)`), so per-call job options do not accept `wait` or `wait_until`.
 
 Existing applications need the `step_job_options` column before per-call options can be persisted:
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1227,7 +1227,7 @@ The method is thread-safe and won't affect other concurrent requests.
 
 ### Custom Job Options
 
-Override the queue or priority for all steps in a workflow:
+Override the queue or priority for all steps in a workflow class:
 
 ```ruby
 class HighPriorityWorkflow < GenevaDrive::Workflow
@@ -1239,7 +1239,27 @@ class HighPriorityWorkflow < GenevaDrive::Workflow
 end
 ```
 
-The options are passed directly to ActiveJob's `set` method.
+You can also override those options for a single workflow instance:
+
+```ruby
+SyncGmailWorkflow.create!(
+  hero: connected_account,
+  step_job_options: {queue: :high, priority: 5}
+)
+```
+
+The per-call options are persisted on the workflow row and merged over the class-level options. That means later steps, reattempts, and resumed scheduled executions keep the same queue or priority. This is useful when the same workflow can be started by both low-priority background polling and high-priority user actions: keep one workflow class for dedupe, but give the user-triggered run priority treatment.
+
+Supported keys are the ActiveJob `set` options GenevaDrive passes through: `queue`, `priority`, `wait`, and `wait_until`. Step scheduling remains authoritative for actual step delays, so a step's own `wait:` still sets the runtime `wait_until`.
+
+Existing applications need the `step_job_options` column before per-call options can be persisted:
+
+```bash
+bin/rails generate geneva_drive:install
+bin/rails db:migrate
+```
+
+The generator adds a nullable `geneva_drive_workflows.step_job_options` column if it is missing. This is an additive migration on PostgreSQL, MySQL, and SQLite.
 
 ## Housekeeping
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ bin/rails generate geneva_drive:install
 bin/rails db:migrate
 ```
 
+When updating GenevaDrive in an existing application, run the generator again:
+
+```bash
+bin/rails generate geneva_drive:install
+bin/rails db:migrate
+```
+
+The generator is safe to rerun. It adds any GenevaDrive migrations that are missing for your installed version. For example, versions with per-workflow job options add a nullable `step_job_options` column to `geneva_drive_workflows`.
+
 You should also add the housekeeping job to your background job cron table
 (below example is for `recurring.yml` in solid_queue):
 
@@ -66,6 +75,17 @@ end
 ```ruby
 SignupWorkflow.create!(hero: current_user)
 ```
+
+You can override the ActiveJob options for a single workflow instance:
+
+```ruby
+SignupWorkflow.create!(
+  hero: current_user,
+  step_job_options: {queue: :high, priority: 5}
+)
+```
+
+`step_job_options:` is persisted with the workflow and merged over the class defaults from `set_step_job_options`. Later steps, reattempts, and resumed scheduled executions keep using the same override. This lets a user-triggered workflow run on a high-priority queue without creating a subclass, so ongoing-workflow dedupe still uses the same workflow class.
 
 ### Flow Control
 

--- a/docs/plans/issue-28-per-call-step-job-options.md
+++ b/docs/plans/issue-28-per-call-step-job-options.md
@@ -1,0 +1,79 @@
+---
+status: completed
+created: 2026-05-15
+origin: https://github.com/julik/geneva_drive/issues/28
+---
+
+# Per-Call Step Job Options
+
+## Problem
+
+GenevaDrive currently supports `set_step_job_options` only at the workflow class level. That makes queue and priority choices global for every instance of a workflow class. Issue #28 asks for a per-call override so a single workflow class can serve both background pollers and user-triggered actions without splitting into subclasses and losing the existing uniqueness guarantee for ongoing workflows.
+
+## Scope
+
+Implement explicit `step_job_options:` support on `GenevaDrive::Workflow.create` and `create!`. The override should merge with class-level `_step_job_options`, persist on the workflow row, and be used whenever the workflow enqueues step jobs, including initial steps, scheduled future steps, and reattempts.
+
+The shorthand `queue:` / `priority:` create API is out of scope for this pass. The explicit hash mirrors the existing class-level setter and avoids collisions with Rails model attributes or future workflow creation options.
+
+## Requirements Traceability
+
+- Issue #28 requires overrides to merge into, not replace, class-level options.
+- Issue #28 requires workflow class identity and `validate_unique_ongoing_workflow` behavior to stay unchanged.
+- Issue #28 prefers persistence so reattempts and resumed/scheduled steps keep the override.
+- Issue #28 calls out ActiveJob `set` compatibility for `queue`, `priority`, `wait`, and `wait_until`.
+
+## Implementation Units
+
+### 1. Persist Per-Workflow Job Options
+
+Files:
+- `lib/geneva_drive/workflow.rb`
+- `lib/generators/geneva_drive/install/templates/create_workflows_migration.rb`
+- `lib/generators/geneva_drive/install/templates/add_step_job_options_to_workflows.rb`
+- `lib/generators/geneva_drive/install/install_generator.rb`
+
+Add a nullable `step_job_options` column to the workflows table using JSONB on PostgreSQL, large text on MySQL, and text on SQLite. This is an additive migration and avoids SQLite table rewrites. Existing installs should receive an upgrade migration from the install generator, and new installs should get the column in the create-table template.
+
+In `GenevaDrive::Workflow`, provide guarded serialization helpers similar in spirit to `GenevaDrive::StepExecution::MetadataAccessor`: handle JSON text storage, tolerate the column being absent during upgrade windows, and normalize options into a hash with symbol keys before enqueueing.
+
+### 2. Accept `step_job_options:` During Creation
+
+Files:
+- `lib/geneva_drive/workflow.rb`
+- `test/workflow/workflow_test.rb`
+
+Teach workflow instances to accept the `step_job_options:` attribute through normal ActiveRecord creation. Validate option keys against the ActiveJob `set` options supported by the requested behavior: `queue`, `priority`, `wait`, and `wait_until`. Invalid keys should fail validation rather than being silently ignored.
+
+The stored override should not participate in uniqueness lookup. The existing `validate_unique_ongoing_workflow` query should continue to scope only by workflow type, hero, state, and `allow_multiple`.
+
+### 3. Use Merged Options for Every Step Enqueue
+
+Files:
+- `lib/geneva_drive/workflow.rb`
+- `test/workflow/workflow_test.rb`
+
+Replace direct uses of `self.class._step_job_options.dup` in `create_step_execution` and `enqueue_scheduled_execution` with a helper that merges class-level options and instance-level overrides. Runtime scheduling should still set `wait_until` after that merge so the step's actual schedule cannot be accidentally overridden by persisted creation options.
+
+## Existing Patterns
+
+- `set_step_job_options` in `lib/geneva_drive/workflow.rb` already defines class-level defaults and should remain the base layer.
+- `create_step_execution` and `enqueue_scheduled_execution` are the only current enqueue points that call `PerformStepJob.set`.
+- `GenevaDrive::StepExecution::MetadataAccessor` demonstrates guarded JSON/text storage during upgrade windows.
+- Generator templates already use adapter-specific JSONB/text choices for metadata without adding SQLite foreign keys or forcing table rewrites.
+
+## Test Scenarios
+
+- Creating a workflow with `step_job_options: { queue: :high }` persists the override and enqueues the initial step job on `high`.
+- Class-level options and per-call options merge, for example class priority plus instance queue.
+- Per-call options override conflicting class-level values.
+- A delayed or scheduled later step keeps the per-workflow queue/priority while using the step's runtime `wait_until`.
+- An invalid `step_job_options` key makes workflow creation invalid.
+- A duplicate workflow for the same class and hero is still rejected even when `step_job_options` differ.
+- Serialization round-trips through reload so persisted overrides are available after the workflow object is reloaded.
+
+## Risks
+
+- ActiveJob adapters may serialize queue names as strings even when the caller passes symbols, so tests should assert observable queue names in adapter-compatible form.
+- The upgrade window before the new column exists should not break existing apps that create workflows without overrides.
+- Persisting `wait` or `wait_until` as a default option could conflict with step scheduling. Runtime scheduling must remain authoritative for actual step timing.

--- a/docs/plans/issue-28-per-call-step-job-options.md
+++ b/docs/plans/issue-28-per-call-step-job-options.md
@@ -21,7 +21,7 @@ The shorthand `queue:` / `priority:` create API is out of scope for this pass. T
 - Issue #28 requires overrides to merge into, not replace, class-level options.
 - Issue #28 requires workflow class identity and `validate_unique_ongoing_workflow` behavior to stay unchanged.
 - Issue #28 prefers persistence so reattempts and resumed/scheduled steps keep the override.
-- Issue #28 calls out ActiveJob `set` compatibility for `queue`, `priority`, `wait`, and `wait_until`.
+- Issue #28 calls out ActiveJob `set` compatibility. This implementation supports per-call `queue` and `priority` only, leaving `wait` and `wait_until` to GenevaDrive's step scheduling APIs to avoid conflicting timing semantics.
 
 ## Implementation Units
 
@@ -43,7 +43,7 @@ Files:
 - `lib/geneva_drive/workflow.rb`
 - `test/workflow/workflow_test.rb`
 
-Teach workflow instances to accept the `step_job_options:` attribute through normal ActiveRecord creation. Validate option keys against the ActiveJob `set` options supported by the requested behavior: `queue`, `priority`, `wait`, and `wait_until`. Invalid keys should fail validation rather than being silently ignored.
+Teach workflow instances to accept the `step_job_options:` attribute through normal ActiveRecord creation. Validate option keys against the ActiveJob `set` options supported by the requested behavior: `queue` and `priority`. Invalid keys should fail validation rather than being silently ignored.
 
 The stored override should not participate in uniqueness lookup. The existing `validate_unique_ongoing_workflow` query should continue to scope only by workflow type, hero, state, and `allow_multiple`.
 
@@ -53,7 +53,7 @@ Files:
 - `lib/geneva_drive/workflow.rb`
 - `test/workflow/workflow_test.rb`
 
-Replace direct uses of `self.class._step_job_options.dup` in `create_step_execution` and `enqueue_scheduled_execution` with a helper that merges class-level options and instance-level overrides. Runtime scheduling should still set `wait_until` after that merge so the step's actual schedule cannot be accidentally overridden by persisted creation options.
+Replace direct uses of `self.class._step_job_options.dup` in `create_step_execution` and `enqueue_scheduled_execution` with a helper that merges class-level options and instance-level queue/priority overrides. Runtime scheduling remains owned by step definitions and flow-control APIs.
 
 ## Existing Patterns
 
@@ -67,7 +67,7 @@ Replace direct uses of `self.class._step_job_options.dup` in `create_step_execut
 - Creating a workflow with `step_job_options: { queue: :high }` persists the override and enqueues the initial step job on `high`.
 - Class-level options and per-call options merge, for example class priority plus instance queue.
 - Per-call options override conflicting class-level values.
-- A delayed or scheduled later step keeps the per-workflow queue/priority while using the step's runtime `wait_until`.
+- A delayed or scheduled later step keeps the per-workflow queue/priority while using the step's own schedule.
 - An invalid `step_job_options` key makes workflow creation invalid.
 - A duplicate workflow for the same class and hero is still rejected even when `step_job_options` differ.
 - Serialization round-trips through reload so persisted overrides are available after the workflow object is reloaded.
@@ -76,4 +76,4 @@ Replace direct uses of `self.class._step_job_options.dup` in `create_step_execut
 
 - ActiveJob adapters may serialize queue names as strings even when the caller passes symbols, so tests should assert observable queue names in adapter-compatible form.
 - The upgrade window before the new column exists should not break existing apps that create workflows without overrides.
-- Persisting `wait` or `wait_until` as a default option could conflict with step scheduling. Runtime scheduling must remain authoritative for actual step timing.
+- Per-call `wait` and `wait_until` would conflict with step scheduling, so those keys are rejected.

--- a/lib/generators/geneva_drive/install/install_generator.rb
+++ b/lib/generators/geneva_drive/install/install_generator.rb
@@ -50,6 +50,11 @@ module GenevaDrive
           "allow_null_hero_on_workflows.rb",
           "db/migrate/allow_null_hero_on_geneva_drive_workflows.rb"
         )
+
+        migration_template(
+          "add_step_job_options_to_workflows.rb",
+          "db/migrate/add_step_job_options_to_geneva_drive_workflows.rb"
+        )
       end
 
       # Creates the initializer file.

--- a/lib/generators/geneva_drive/install/templates/add_step_job_options_to_workflows.rb
+++ b/lib/generators/geneva_drive/install/templates/add_step_job_options_to_workflows.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddStepJobOptionsToGenevaDriveWorkflows < ActiveRecord::Migration[7.2]
+  def change
+    return if column_exists?(:geneva_drive_workflows, :step_job_options)
+
+    adapter = connection.adapter_name.downcase
+
+    if adapter.include?("postgresql")
+      add_column :geneva_drive_workflows, :step_job_options, :jsonb
+    elsif adapter.include?("mysql")
+      add_column :geneva_drive_workflows, :step_job_options, :text, limit: 4_294_967_295
+    else
+      add_column :geneva_drive_workflows, :step_job_options, :text
+    end
+  end
+end

--- a/lib/generators/geneva_drive/install/templates/create_workflows_migration.rb
+++ b/lib/generators/geneva_drive/install/templates/create_workflows_migration.rb
@@ -22,6 +22,15 @@ class CreateGenevaDriveWorkflows < ActiveRecord::Migration[7.2]
       # Multiple workflows of same type for same hero
       t.boolean :allow_multiple, default: false, null: false
 
+      # Per-workflow ActiveJob options for step execution jobs
+      if connection.adapter_name.downcase.include?("postgresql")
+        t.jsonb :step_job_options
+      elsif connection.adapter_name.downcase.include?("mysql")
+        t.text :step_job_options, limit: 4_294_967_295
+      else
+        t.text :step_job_options
+      end
+
       # Timestamps
       t.datetime :started_at
       t.datetime :transitioned_at

--- a/lib/geneva_drive/workflow.rb
+++ b/lib/geneva_drive/workflow.rb
@@ -22,6 +22,8 @@
 class GenevaDrive::Workflow < ActiveRecord::Base
   self.table_name = "geneva_drive_workflows"
 
+  VALID_STEP_JOB_OPTION_KEYS = %i[queue priority wait wait_until].freeze
+
   # Workflow states as enum with string values
   # Provides: ready?, performing?, etc. predicates
   # Provides: ready, performing, etc. scopes
@@ -53,6 +55,7 @@ class GenevaDrive::Workflow < ActiveRecord::Base
 
   # Validations
   validate :validate_unique_ongoing_workflow, if: -> { !allow_multiple && ongoing? }
+  validate :validate_step_job_options
 
   # Additional scopes
   scope :ongoing, -> { where.not(state: %w[finished canceled]) }
@@ -182,6 +185,14 @@ class GenevaDrive::Workflow < ActiveRecord::Base
     def set_step_job_options(**options)
       # Merge with parent's options
       self._step_job_options = _step_job_options.merge(options)
+    end
+
+    # Whether this installation has migrated the per-workflow job options column.
+    # Kept lazy so apps can boot safely during upgrade windows.
+    #
+    # @return [Boolean]
+    def step_job_options_column?
+      table_exists? && column_names.include?("step_job_options")
     end
 
     # Allows the workflow to continue even if the hero is deleted.
@@ -552,7 +563,151 @@ class GenevaDrive::Workflow < ActiveRecord::Base
     end
   end
 
+  # Returns per-workflow ActiveJob options that were supplied at creation time.
+  #
+  # @return [Hash]
+  def step_job_options
+    normalized_step_job_options
+  end
+
+  # Stores per-workflow ActiveJob options for future step enqueues.
+  #
+  # @param options [Hash, nil] ActiveJob set options
+  # @return [void]
+  def step_job_options=(options)
+    @step_job_options_input = options
+    remove_instance_variable(:@step_job_options_serialization_error) if defined?(@step_job_options_serialization_error)
+
+    if options.blank?
+      @step_job_options_override = {}
+      write_step_job_options_attribute(nil)
+      return
+    end
+
+    unless options.respond_to?(:to_h)
+      @step_job_options_override = options
+      return
+    end
+
+    @step_job_options_override = normalize_step_job_options_hash(options.to_h)
+    write_step_job_options_attribute(serialize_step_job_options(@step_job_options_override))
+  rescue ActiveJob::SerializationError => error
+    @step_job_options_serialization_error = error
+  end
+
+  # Clears cached per-workflow job options when ActiveRecord reloads attributes.
+  #
+  # @return [GenevaDrive::Workflow]
+  def reload(...)
+    remove_instance_variable(:@step_job_options_input) if defined?(@step_job_options_input)
+    remove_instance_variable(:@step_job_options_override) if defined?(@step_job_options_override)
+    remove_instance_variable(:@step_job_options_serialization_error) if defined?(@step_job_options_serialization_error)
+
+    super
+  end
+
   private
+
+  # Returns the raw user input when present, otherwise the stored value.
+  #
+  # @return [Object]
+  def raw_step_job_options
+    if defined?(@step_job_options_input)
+      @step_job_options_input
+    elsif defined?(@step_job_options_override)
+      @step_job_options_override
+    else
+      deserialize_step_job_options(read_step_job_options_attribute)
+    end
+  end
+
+  # Returns normalized per-workflow options with symbol keys.
+  #
+  # @return [Hash]
+  def normalized_step_job_options
+    raw = if defined?(@step_job_options_override)
+      @step_job_options_override
+    else
+      deserialize_step_job_options(read_step_job_options_attribute)
+    end
+
+    return {} unless raw.respond_to?(:to_h)
+
+    normalize_step_job_options_hash(raw.to_h)
+  end
+
+  # Returns class-level options merged with persisted instance overrides.
+  #
+  # @return [Hash]
+  def merged_step_job_options
+    self.class._step_job_options.merge(normalized_step_job_options)
+  end
+
+  # Normalizes job option hash keys for ActiveJob#set keyword splatting.
+  #
+  # @param options [Hash]
+  # @return [Hash]
+  def normalize_step_job_options_hash(options)
+    options.each_with_object({}) do |(key, value), normalized|
+      normalized[key.to_s.to_sym] = value
+    end
+  end
+
+  # Serializes options through ActiveJob so JSON/text storage preserves
+  # supported Ruby values such as symbols and times.
+  #
+  # @param options [Hash]
+  # @return [Hash]
+  def serialize_step_job_options(options)
+    ActiveJob::Arguments.serialize([options]).first
+  end
+
+  # Deserializes options previously serialized through ActiveJob.
+  #
+  # @param raw [Object]
+  # @return [Hash]
+  def deserialize_step_job_options(raw)
+    parsed = case raw
+    when Hash then raw
+    when String then JSON.parse(raw)
+    when NilClass then {}
+    else {}
+    end
+
+    deserialized = ActiveJob::Arguments.deserialize([parsed]).first
+    return {} unless deserialized.respond_to?(:to_h)
+
+    deserialized.to_h
+  rescue JSON::ParserError, ActiveJob::DeserializationError
+    {}
+  end
+
+  # Reads the storage attribute only when the migration has been installed.
+  #
+  # @return [Object, nil]
+  def read_step_job_options_attribute
+    return nil unless self.class.step_job_options_column? && has_attribute?(:step_job_options)
+
+    read_attribute(:step_job_options)
+  end
+
+  # Writes the storage attribute only when the migration has been installed.
+  #
+  # @param serialized_options [Hash, nil]
+  # @return [void]
+  def write_step_job_options_attribute(serialized_options)
+    return unless self.class.step_job_options_column? && has_attribute?(:step_job_options)
+
+    value = if serialized_options.nil?
+      nil
+    elsif self.class.columns_hash["step_job_options"].type.in?([:json, :jsonb])
+      serialized_options
+    else
+      serialized_options.to_json
+    end
+
+    write_attribute(:step_job_options, value)
+  end
 
   # Validates that no other ongoing workflow exists for the same (type, hero).
   # Mirrors the database unique index on (type, hero_type, hero_id) for ongoing workflows.
@@ -566,6 +721,29 @@ class GenevaDrive::Workflow < ActiveRecord::Base
     if scope.exists?
       errors.add(:base, "An ongoing workflow of this type already exists for this hero")
     end
+  end
+
+  # Validates per-workflow ActiveJob options before they are persisted.
+  #
+  # @return [void]
+  def validate_step_job_options
+    return if raw_step_job_options.blank?
+
+    unless raw_step_job_options.respond_to?(:to_h)
+      errors.add(:step_job_options, "must be a hash")
+      return
+    end
+
+    invalid_keys = raw_step_job_options.to_h.keys.map { |key| key.to_s.to_sym } - VALID_STEP_JOB_OPTION_KEYS
+    if invalid_keys.any?
+      errors.add(:step_job_options, "contains unsupported option(s): #{invalid_keys.join(", ")}")
+    end
+
+    raise @step_job_options_serialization_error if defined?(@step_job_options_serialization_error)
+
+    ActiveJob::Arguments.serialize([normalized_step_job_options])
+  rescue ActiveJob::SerializationError, ActiveJob::DeserializationError => error
+    errors.add(:step_job_options, "contains unserializable value: #{error.message}")
   end
 
   # Logs when a workflow is created.
@@ -605,7 +783,7 @@ class GenevaDrive::Workflow < ActiveRecord::Base
     logger.info("Enqueuing job for step #{step_execution.step_name} to run #{wait_msg}")
 
     # Capture values for the callback
-    job_options = self.class._step_job_options.dup
+    job_options = merged_step_job_options
     job_options[:wait_until] = wait_until if wait_until
     execution_id = step_execution.id
     workflow_logger = logger
@@ -661,7 +839,7 @@ class GenevaDrive::Workflow < ActiveRecord::Base
       update!(next_step_name: step_definition.name)
 
       # Capture values for the after_commit callback
-      job_options = self.class._step_job_options.dup
+      job_options = merged_step_job_options
       job_options[:wait_until] = scheduled_for if wait
       execution_id = step_execution.id
       workflow_logger = logger

--- a/lib/geneva_drive/workflow.rb
+++ b/lib/geneva_drive/workflow.rb
@@ -22,7 +22,7 @@
 class GenevaDrive::Workflow < ActiveRecord::Base
   self.table_name = "geneva_drive_workflows"
 
-  VALID_STEP_JOB_OPTION_KEYS = %i[queue priority wait wait_until].freeze
+  VALID_STEP_JOB_OPTION_KEYS = %i[queue priority].freeze
 
   # Workflow states as enum with string values
   # Provides: ready?, performing?, etc. predicates
@@ -654,7 +654,7 @@ class GenevaDrive::Workflow < ActiveRecord::Base
   end
 
   # Serializes options through ActiveJob so JSON/text storage preserves
-  # supported Ruby values such as symbols and times.
+  # queue names passed as symbols.
   #
   # @param options [Hash]
   # @return [Hash]

--- a/test/workflow/workflow_test.rb
+++ b/test/workflow/workflow_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class WorkflowTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   # Basic workflow for testing
   class SimpleWorkflow < GenevaDrive::Workflow
     step :step_one do
@@ -125,8 +127,21 @@ class WorkflowTest < ActiveSupport::TestCase
     end
   end
 
+  class PerCallJobOptionsWorkflow < GenevaDrive::Workflow
+    set_step_job_options queue: :default_queue, priority: 10
+
+    step :first_step do
+      # First step
+    end
+
+    step :delayed_step, wait: 1.hour do
+      # Delayed step
+    end
+  end
+
   setup do
     @user = create_user
+    clear_enqueued_jobs
   end
 
   test "creates workflow with hero and schedules first step" do
@@ -155,6 +170,92 @@ class WorkflowTest < ActiveSupport::TestCase
     options = ChildWorkflow._step_job_options
     assert_equal :base_queue, options[:queue]
     assert_equal 10, options[:priority]
+  end
+
+  test "per-call step job options override class queue for initial enqueue" do
+    clear_enqueued_jobs
+
+    workflow = PerCallJobOptionsWorkflow.create!(
+      hero: @user,
+      step_job_options: {queue: :high_priority}
+    )
+
+    assert_equal({queue: :high_priority}, workflow.step_job_options)
+    assert_enqueued_with(
+      job: GenevaDrive::PerformStepJob,
+      args: [workflow.step_executions.first.id],
+      queue: "high_priority"
+    )
+  end
+
+  test "per-call step job options merge with class-level options" do
+    clear_enqueued_jobs
+
+    PerCallJobOptionsWorkflow.create!(
+      hero: @user,
+      step_job_options: {queue: :high_priority}
+    )
+
+    job = ActiveJob::Base.queue_adapter.enqueued_jobs.last
+    assert_equal "high_priority", job[:queue]
+    assert_equal 10, job[:priority]
+  end
+
+  test "per-call step job options are persisted and restored after reload" do
+    workflow = PerCallJobOptionsWorkflow.create!(
+      hero: @user,
+      step_job_options: {queue: :high_priority, priority: 5}
+    )
+
+    persisted = PerCallJobOptionsWorkflow.find(workflow.id)
+    assert_equal({queue: :high_priority, priority: 5}, persisted.step_job_options)
+  end
+
+  test "scheduled later steps use persisted per-call step job options" do
+    clear_enqueued_jobs
+
+    workflow = PerCallJobOptionsWorkflow.create!(
+      hero: @user,
+      step_job_options: {queue: :high_priority}
+    )
+
+    execution_id = workflow.step_executions.first.id
+
+    clear_enqueued_jobs
+    GenevaDrive::StepExecution.find(execution_id).execute!
+
+    delayed_execution = workflow.step_executions.find_by!(step_name: "delayed_step")
+    assert_enqueued_with(
+      job: GenevaDrive::PerformStepJob,
+      args: [delayed_execution.id],
+      queue: "high_priority",
+      at: delayed_execution.scheduled_for
+    )
+  end
+
+  test "invalid per-call step job option keys are rejected" do
+    workflow = PerCallJobOptionsWorkflow.new(
+      hero: @user,
+      step_job_options: {unknown: true}
+    )
+
+    assert_not workflow.valid?
+    assert_includes workflow.errors[:step_job_options].join, "unsupported option"
+  end
+
+  test "per-call step job options do not affect unique ongoing workflow scope" do
+    PerCallJobOptionsWorkflow.create!(
+      hero: @user,
+      step_job_options: {queue: :high_priority}
+    )
+
+    duplicate = PerCallJobOptionsWorkflow.new(
+      hero: @user,
+      step_job_options: {queue: :low_priority}
+    )
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:base], "An ongoing workflow of this type already exists for this hero"
   end
 
   test "may_proceed_without_hero! is inherited" do

--- a/test/workflow/workflow_test.rb
+++ b/test/workflow/workflow_test.rb
@@ -243,6 +243,18 @@ class WorkflowTest < ActiveSupport::TestCase
     assert_includes workflow.errors[:step_job_options].join, "unsupported option"
   end
 
+  test "per-call step job options reject scheduling keys" do
+    %i[wait wait_until].each do |key|
+      workflow = PerCallJobOptionsWorkflow.new(
+        hero: @user,
+        step_job_options: {key => 1.hour.from_now}
+      )
+
+      assert_not workflow.valid?
+      assert_includes workflow.errors[:step_job_options].join, "unsupported option"
+    end
+  end
+
   test "per-call step job options do not affect unique ongoing workflow scope" do
     PerCallJobOptionsWorkflow.create!(
       hero: @user,


### PR DESCRIPTION
## Summary

Workflow callers can now choose queue and priority per workflow creation without forking the workflow class. `step_job_options:` is persisted on the workflow row, merged over class defaults, and reused whenever that workflow enqueues step jobs, so user-triggered runs can get priority treatment while the existing per-class dedupe behavior stays intact.

The storage uses an additive, nullable column in the install generator templates, with guarded runtime access so apps can boot during upgrade windows before the migration has been applied.

## Verification

- `bin/rails test test/workflow/workflow_test.rb`
- `bin/rails test`
- `bundle exec standardrb`

Closes julik/geneva_drive#28.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
