### PR TITLE
Add metadata column to workflows with step_job_options accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add optional `metadata` JSON column to workflows (mirrors the existing step executions pattern). Exposes `step_job_options` / `step_job_options=` for per-instance job option overrides (queue, priority, etc.) that merge with class-level `set_step_job_options` and persist across step boundaries. Dedupe is unaffected since metadata is not part of the uniqueness constraint.
 - Add GenevaDrive workflow and step metadata to `Rails.error` execution context when steps execute, so Rails error reports include workflow id/class, step execution id/name, and hero identifiers.
 - Add `report:` option to exception policies and class-level `on_exception` for controlling when exceptions are reported to `Rails.error.report`. Accepts `:always` (default — preserves existing behavior), `:never` (suppress reporting for expected exceptions like rate limits), or `:terminal_only` (suppress during reattempts, report only when `terminal_action` fires). The executor now defers error reporting until after policy resolution.
 

--- a/lib/generators/geneva_drive/install/install_generator.rb
+++ b/lib/generators/geneva_drive/install/install_generator.rb
@@ -47,6 +47,11 @@ module GenevaDrive
         )
 
         migration_template(
+          "add_metadata_to_workflows.rb",
+          "db/migrate/add_metadata_to_geneva_drive_workflows.rb"
+        )
+
+        migration_template(
           "allow_null_hero_on_workflows.rb",
           "db/migrate/allow_null_hero_on_geneva_drive_workflows.rb"
         )

--- a/lib/generators/geneva_drive/install/templates/add_metadata_to_workflows.rb
+++ b/lib/generators/geneva_drive/install/templates/add_metadata_to_workflows.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddMetadataToGenevaDriveWorkflows < ActiveRecord::Migration[7.2]
+  def change
+    return if column_exists?(:geneva_drive_workflows, :metadata)
+
+    adapter = connection.adapter_name.downcase
+
+    if adapter.include?("postgresql")
+      add_column :geneva_drive_workflows, :metadata, :jsonb
+    elsif adapter.include?("mysql")
+      add_column :geneva_drive_workflows, :metadata, :text, limit: 4_294_967_295
+    else
+      add_column :geneva_drive_workflows, :metadata, :text
+    end
+  end
+end

--- a/lib/generators/geneva_drive/install/templates/create_workflows_migration.rb
+++ b/lib/generators/geneva_drive/install/templates/create_workflows_migration.rb
@@ -4,6 +4,8 @@ class CreateGenevaDriveWorkflows < ActiveRecord::Migration[7.2]
   include GenevaDrive::MigrationHelpers
 
   def change
+    adapter = connection.adapter_name.downcase
+
     create_table :geneva_drive_workflows, **geneva_drive_table_options do |t|
       # Core identification (STI)
       t.string :type, null: false, index: true
@@ -21,6 +23,15 @@ class CreateGenevaDriveWorkflows < ActiveRecord::Migration[7.2]
 
       # Multiple workflows of same type for same hero
       t.boolean :allow_multiple, default: false, null: false
+
+      # Freeform JSON metadata
+      if adapter.include?("postgresql")
+        t.jsonb :metadata
+      elsif adapter.include?("mysql")
+        t.text :metadata, limit: 4_294_967_295
+      else
+        t.text :metadata
+      end
 
       # Timestamps
       t.datetime :started_at

--- a/lib/geneva_drive/workflow.rb
+++ b/lib/geneva_drive/workflow.rb
@@ -22,6 +22,9 @@
 class GenevaDrive::Workflow < ActiveRecord::Base
   self.table_name = "geneva_drive_workflows"
 
+  require_relative "workflow/metadata_accessor"
+  include MetadataAccessor
+
   # Workflow states as enum with string values
   # Provides: ready?, performing?, etc. predicates
   # Provides: ready, performing, etc. scopes
@@ -537,6 +540,25 @@ class GenevaDrive::Workflow < ActiveRecord::Base
     yield
   end
 
+  # Returns per-instance step job options stored in metadata.
+  # These are merged with the class-level options when enqueuing step jobs,
+  # with instance options taking precedence.
+  #
+  # @return [Hash] symbolized job options (e.g. `{ queue: :high, priority: 5 }`)
+  def step_job_options
+    (read_metadata("step_job_options") || {}).symbolize_keys
+  end
+
+  # Sets per-instance step job options in metadata.
+  # Stored as part of the workflow's metadata column so they persist and
+  # survive across step boundaries.
+  #
+  # @param options [Hash, nil] job options to store
+  # @return [void]
+  def step_job_options=(options)
+    write_metadata("step_job_options", options.presence&.stringify_keys)
+  end
+
   # Transitions the workflow to a new state.
   #
   # @param new_state [String] the target state
@@ -553,6 +575,14 @@ class GenevaDrive::Workflow < ActiveRecord::Base
   end
 
   private
+
+  # Returns class-level step job options merged with per-instance overrides.
+  # Instance options (from metadata) take precedence over class-level ones.
+  #
+  # @return [Hash] merged job options
+  def merged_step_job_options
+    self.class._step_job_options.merge(step_job_options)
+  end
 
   # Validates that no other ongoing workflow exists for the same (type, hero).
   # Mirrors the database unique index on (type, hero_type, hero_id) for ongoing workflows.
@@ -605,7 +635,7 @@ class GenevaDrive::Workflow < ActiveRecord::Base
     logger.info("Enqueuing job for step #{step_execution.step_name} to run #{wait_msg}")
 
     # Capture values for the callback
-    job_options = self.class._step_job_options.dup
+    job_options = merged_step_job_options
     job_options[:wait_until] = wait_until if wait_until
     execution_id = step_execution.id
     workflow_logger = logger
@@ -661,7 +691,7 @@ class GenevaDrive::Workflow < ActiveRecord::Base
       update!(next_step_name: step_definition.name)
 
       # Capture values for the after_commit callback
-      job_options = self.class._step_job_options.dup
+      job_options = merged_step_job_options
       job_options[:wait_until] = scheduled_for if wait
       execution_id = step_execution.id
       workflow_logger = logger

--- a/lib/geneva_drive/workflow/metadata_accessor.rb
+++ b/lib/geneva_drive/workflow/metadata_accessor.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# Provides safe read/write access to the freeform JSON metadata column
+# on workflows. All "does the column exist?" logic lives here so
+# the rest of the codebase can call read_metadata / write_metadata without
+# guarding. When the metadata column has not been migrated yet, writes
+# are silent no-ops and reads return nil.
+#
+# Once the migration becomes mandatory, delete this concern and replace with
+# a plain `attribute :metadata, :json, default: -> { {} }` on Workflow.
+#
+# @api private
+module GenevaDrive::Workflow::MetadataAccessor
+  extend ActiveSupport::Concern
+
+  class_methods do
+    # Lazily checks whether the metadata column exists. Never hits the
+    # database at class definition time — only on the first runtime call.
+    #
+    # Serialization is handled manually in read/write_metadata rather
+    # than via `attribute :metadata, :json` to avoid timing issues —
+    # registering the JSON type after instances are already loaded
+    # causes those instances to persist Hashes via text-type `#to_s`
+    # instead of `#to_json`.
+    #
+    # @return [Boolean]
+    def metadata_column?
+      if defined?(@_metadata_column)
+        return @_metadata_column
+      end
+
+      @_metadata_column = table_exists? && column_names.include?("metadata")
+    end
+
+    # Clears the cached detection result. Call this in tests or after
+    # running migrations in-process so the next access re-checks.
+    #
+    # @return [void]
+    def reset_metadata_column_cache!
+      remove_instance_variable(:@_metadata_column) if defined?(@_metadata_column)
+    end
+  end
+
+  # Reads a single key from the metadata hash.
+  #
+  # @param key [String, Symbol] the metadata key
+  # @return [Object, nil] the value, or nil if the column is absent
+  def read_metadata(key)
+    return nil unless self.class.metadata_column?
+    parsed_metadata[key.to_s]
+  end
+
+  # Merges a key/value pair into the metadata hash (in-memory only, does
+  # not persist — call save!/update! separately or include in a broader
+  # update).
+  #
+  # @param key [String, Symbol] the metadata key
+  # @param value [Object] the value to store
+  # @return [void]
+  def write_metadata(key, value)
+    return unless self.class.metadata_column?
+    merged = parsed_metadata.merge(key.to_s => value)
+    write_attribute(:metadata, merged.to_json)
+  end
+
+  private
+
+  # Returns metadata as a Hash regardless of whether the JSON attribute
+  # type has been applied to this instance. On SQLite/MySQL the raw value
+  # may still be a JSON string if the record was loaded before the
+  # attribute type was lazily registered.
+  #
+  # @return [Hash]
+  def parsed_metadata
+    raw = metadata
+    case raw
+    when Hash then raw
+    when String then JSON.parse(raw)
+    when NilClass then {}
+    else {}
+    end
+  rescue JSON::ParserError
+    {}
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,6 +54,7 @@ class ActiveSupport::TestCase
   # same parallel process.
   setup do
     GenevaDrive::StepExecution.reset_metadata_column_cache!
+    GenevaDrive::Workflow.reset_metadata_column_cache!
   end
 
   # Helper to create a test user

--- a/test/workflow/workflow_test.rb
+++ b/test/workflow/workflow_test.rb
@@ -395,4 +395,75 @@ class WorkflowTest < ActiveSupport::TestCase
     assert_equal "finished", workflow.state
     assert_nil workflow.previous_step_name
   end
+
+  # Workflow with class-level job options for per-instance override testing
+  class ClassQueueWorkflow < GenevaDrive::Workflow
+    set_step_job_options queue: :default_queue, priority: 5
+
+    step :step_one do
+      # step one
+    end
+
+    step :step_two do
+      # step two
+    end
+  end
+
+  test "step_job_options= persists via metadata and survives reload" do
+    workflow = ClassQueueWorkflow.new(hero: @user)
+    workflow.step_job_options = {queue: :high}
+    workflow.save!
+
+    workflow.reload
+    # Values round-trip through JSON as strings; keys are symbolized
+    assert_equal({queue: "high"}, workflow.step_job_options)
+  end
+
+  test "step_job_options merges with class-level options, instance wins" do
+    workflow = ClassQueueWorkflow.new(hero: @user)
+    workflow.step_job_options = {queue: :critical}
+    workflow.save!
+
+    merged = workflow.send(:merged_step_job_options)
+    assert_equal "critical", merged[:queue]
+    assert_equal 5, merged[:priority]
+  end
+
+  test "per-instance step_job_options are used when enqueuing first step" do
+    workflow = ClassQueueWorkflow.new(hero: @user)
+    workflow.step_job_options = {queue: :high}
+    workflow.save!
+
+    enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs.last
+    assert_equal "high", enqueued[:queue]
+  end
+
+  test "per-instance step_job_options are used for subsequent steps" do
+    workflow = ClassQueueWorkflow.new(hero: @user)
+    workflow.step_job_options = {queue: :high}
+    workflow.save!
+
+    # Clear the first step's enqueued job and simulate scheduling the next step
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    workflow.schedule_next_step!
+
+    enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs.last
+    assert_equal "high", enqueued[:queue]
+  end
+
+  test "dedupe is unaffected by differing step_job_options" do
+    workflow1 = ClassQueueWorkflow.new(hero: @user)
+    workflow1.step_job_options = {queue: :high}
+    workflow1.save!
+
+    workflow2 = ClassQueueWorkflow.new(hero: @user)
+    workflow2.step_job_options = {queue: :low}
+
+    assert_not workflow2.valid?, "should be invalid due to ongoing uniqueness"
+  end
+
+  test "step_job_options defaults to empty hash when unset" do
+    workflow = ClassQueueWorkflow.create!(hero: @user)
+    assert_equal({}, workflow.step_job_options)
+  end
 end


### PR DESCRIPTION
## Summary

- Adds a general-purpose `metadata` JSON column to the workflows table (mirrors the existing step executions pattern)
- Exposes `step_job_options` / `step_job_options=` as a thin accessor that reads/writes one key in that metadata hash
- Per-instance options merge with class-level `set_step_job_options`, with instance options taking precedence
- Dedupe is unaffected since metadata is not part of the uniqueness constraint

Closes #28

## Test plan

- [x] `step_job_options=` persists via metadata and survives reload
- [x] Per-instance options merge with class-level options (instance wins)
- [x] Enqueued jobs use per-instance queue for first and subsequent steps
- [x] Dedupe unaffected by differing step_job_options
- [x] Defaults to empty hash when unset
- [x] Full test suite passes (397 tests, 0 failures)