### PR TITLE
perf(housekeeping): index + order stuck-in_progress recovery batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add partial index on `geneva_drive_step_executions(started_at) WHERE state = 'in_progress'` and order `HousekeepingJob` recovery batches by the filter column (`started_at` for stuck-in-progress, `scheduled_for` for stuck-scheduled). Fixes `HousekeepingJob` timing out on large in-progress sets where most rows are fresh — the planner previously walked the whole `state = 'in_progress'` set looking for old rows and tripped the caller's `statement_timeout`. Fixes AppSignal incident b9a7d1d1.
 - Add a normalized `geneva_drive.paused_ratio` gauge emitted by `HousekeepingJob`. For each workflow class (STI `type`) it reports a float in `0.0..1.0`, tagged `workflow: <ClassName>`, equal to that class's `paused` count divided by its total population (all states). Unlike absolute paused counts, this is bounded and easy to alert on (50 paused of 50 is a fire; 50 of 500,000 is noise). Derived from the existing single grouped query — no extra database load.
 - Add optional `metadata` JSON column to workflows (mirrors the existing step executions pattern). Exposes `step_job_options` / `step_job_options=` for per-instance job option overrides (queue, priority, etc.) that merge with class-level `set_step_job_options` and persist across step boundaries. Dedupe is unaffected since metadata is not part of the uniqueness constraint.
 - Add GenevaDrive workflow and step metadata to `Rails.error` execution context when steps execute, so Rails error reports include workflow id/class, step execution id/name, and hero identifiers.

--- a/lib/generators/geneva_drive/install/install_generator.rb
+++ b/lib/generators/geneva_drive/install/install_generator.rb
@@ -55,6 +55,11 @@ module GenevaDrive
           "allow_null_hero_on_workflows.rb",
           "db/migrate/allow_null_hero_on_geneva_drive_workflows.rb"
         )
+
+        migration_template(
+          "add_started_at_index_to_step_executions.rb",
+          "db/migrate/add_started_at_index_to_geneva_drive_step_executions.rb"
+        )
       end
 
       # Creates the initializer file.

--- a/lib/generators/geneva_drive/install/templates/add_started_at_index_to_step_executions.rb
+++ b/lib/generators/geneva_drive/install/templates/add_started_at_index_to_step_executions.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class AddStartedAtIndexToGenevaDriveStepExecutions < ActiveRecord::Migration[7.2]
+  # Partial index scoped to state = 'in_progress'. HousekeepingJob's
+  # recover_stuck_in_progress! filters `state = 'in_progress' AND
+  # started_at < cutoff LIMIT N`; without this the planner walks the whole
+  # in-progress set looking for old rows and trips the caller's
+  # statement_timeout on large / mostly-fresh workloads.
+  INDEX_NAME = :index_geneva_drive_step_executions_in_progress_started_at
+
+  disable_ddl_transaction!
+
+  def up
+    return if index_name_exists?(:geneva_drive_step_executions, INDEX_NAME)
+
+    adapter = connection.adapter_name.downcase
+
+    if adapter.include?("postgresql")
+      add_index :geneva_drive_step_executions, :started_at,
+        name: INDEX_NAME,
+        where: "state = 'in_progress'",
+        algorithm: :concurrently
+    elsif adapter.include?("sqlite")
+      # SQLite supports partial indexes but has no CONCURRENTLY.
+      add_index :geneva_drive_step_executions, :started_at,
+        name: INDEX_NAME,
+        where: "state = 'in_progress'"
+    else
+      # MySQL does not support partial indexes; fall back to a plain index.
+      # Composite (state, started_at) so the planner can seek by state first.
+      add_index :geneva_drive_step_executions, [:state, :started_at],
+        name: INDEX_NAME
+    end
+  end
+
+  def down
+    return unless index_name_exists?(:geneva_drive_step_executions, INDEX_NAME)
+
+    adapter = connection.adapter_name.downcase
+    if adapter.include?("postgresql")
+      remove_index :geneva_drive_step_executions,
+        name: INDEX_NAME,
+        algorithm: :concurrently
+    else
+      remove_index :geneva_drive_step_executions, name: INDEX_NAME
+    end
+  end
+end

--- a/lib/geneva_drive/jobs/housekeeping_job.rb
+++ b/lib/geneva_drive/jobs/housekeeping_job.rb
@@ -213,6 +213,7 @@ class GenevaDrive::HousekeepingJob < ActiveJob::Base
       stuck_executions = GenevaDrive::StepExecution
         .in_progress
         .where("started_at < ?", cutoff_time)
+        .order(started_at: :asc)
         .limit(batch_size)
         .to_a
 
@@ -242,6 +243,7 @@ class GenevaDrive::HousekeepingJob < ActiveJob::Base
       stuck_executions = GenevaDrive::StepExecution
         .scheduled
         .where("scheduled_for < ?", cutoff_time)
+        .order(scheduled_for: :asc)
         .limit(batch_size)
         .to_a
 

--- a/test/jobs/housekeeping_job_test.rb
+++ b/test/jobs/housekeeping_job_test.rb
@@ -335,6 +335,59 @@ class HousekeepingJobTest < ActiveSupport::TestCase
     assert_equal "scheduled", step_execution.state
   end
 
+  test "recover_stuck_in_progress! orders by started_at ascending and terminates" do
+    GenevaDrive.stuck_in_progress_threshold = 1.hour
+    GenevaDrive.stuck_recovery_action = :cancel
+    GenevaDrive.housekeeping_batch_size = 2
+
+    # 3 stuck (old) + 2 fresh (within threshold, must not be touched)
+    stuck = 3.times.map do |i|
+      wf = SimpleWorkflow.create!(hero: @user, allow_multiple: true)
+      wf.update!(state: "performing")
+      se = wf.step_executions.first
+      se.update!(state: "in_progress", started_at: (3 + i).hours.ago)
+      se
+    end
+
+    fresh = 2.times.map do
+      wf = SimpleWorkflow.create!(hero: @user, allow_multiple: true)
+      wf.update!(state: "performing")
+      se = wf.step_executions.first
+      se.update!(state: "in_progress", started_at: 10.minutes.ago)
+      se
+    end
+
+    result = GenevaDrive::HousekeepingJob.perform_now
+
+    assert_equal 3, result[:stuck_in_progress_recovered]
+    stuck.each { |se| assert_equal "canceled", se.reload.state }
+    fresh.each { |se| assert_equal "in_progress", se.reload.state }
+  end
+
+  test "recover_stuck_scheduled! orders by scheduled_for ascending and terminates" do
+    GenevaDrive.stuck_scheduled_threshold = 1.hour
+    GenevaDrive.stuck_recovery_action = :cancel
+    GenevaDrive.housekeeping_batch_size = 2
+
+    stuck = 3.times.map do |i|
+      wf = SimpleWorkflow.create!(hero: @user, allow_multiple: true)
+      se = wf.step_executions.first
+      se.update!(scheduled_for: (2 + i).hours.ago)
+      se
+    end
+
+    fresh = 2.times.map do
+      wf = SimpleWorkflow.create!(hero: @user, allow_multiple: true)
+      wf.step_executions.first
+    end
+
+    result = GenevaDrive::HousekeepingJob.perform_now
+
+    assert_equal 3, result[:stuck_scheduled_recovered]
+    stuck.each { |se| assert_equal "canceled", se.reload.state }
+    fresh.each { |se| assert_equal "scheduled", se.reload.state }
+  end
+
   # Combined tests
 
   test "performs both cleanup and recovery in one run" do


### PR DESCRIPTION
## Summary

Fixes AppSignal incident `b9a7d1d1` — `PG::QueryCanceled` inside `GenevaDrive::HousekeepingJob#recover_stuck_in_progress!` on downstream Cora prod (2026-08-03).

**Root cause.** The recovery batch query is:

```ruby
GenevaDrive::StepExecution
  .in_progress                          # WHERE state = 'in_progress'
  .where("started_at < ?", cutoff_time) # AND started_at < ?
  .limit(batch_size)                    # LIMIT N   (no ORDER BY)
```

None of the existing indexes cover `started_at`. When most currently-in-progress rows are fresh (`started_at >= cutoff`), Postgres walks the entire `state = 'in_progress'` set trying to find `batch_size` rows that pass the predicate, and trips the caller's `statement_timeout` (10 s in Cora prod). The sibling `recover_stuck_scheduled!` path is fine — the existing `(state, scheduled_for)` index serves it.

**Fix.**

- **New migration** (`add_started_at_index_to_geneva_drive_step_executions.rb`, wired into the install generator so fresh installs and upgrades pick it up):
  - Postgres: partial index on `started_at WHERE state = 'in_progress'`, created `CONCURRENTLY`. Tiny and self-maintaining — only holds live in-progress executions.
  - SQLite: same partial index (no `CONCURRENTLY`).
  - MySQL: composite `(state, started_at)` — MySQL lacks partial indexes.
- **Query fix.** Add `ORDER BY started_at ASC` to `recover_stuck_in_progress!` and `ORDER BY scheduled_for ASC` to `recover_stuck_scheduled!` so `LIMIT` terminates on the index and iteration is deterministic across batches. The prior no-ORDER-BY `LIMIT` was nondeterministic and could silently miss / re-fetch rows between iterations even without the perf bug.

**Downstream note.** Once merged, bump `ref:` in cora's Gemfile and run `bin/rails geneva_drive:install` to pick up the migration.

## Test plan

- [x] Existing 23 housekeeping tests still pass
- [x] New test: seed 3 stuck + 2 fresh in-progress rows with `batch_size = 2`, assert only the 3 stuck get recovered and the loop terminates
- [x] New test: same shape for the scheduled variant
- [ ] After merge in downstream: verify AppSignal incident stops recurring
